### PR TITLE
Stage pydoc/javadoc/etc..

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -16,6 +16,10 @@
 
 # This file is required to publish the Beam Docs.
 
+staging: # staged site will be at https://beam.staged.apache.org/releases/<javadoc/pydoc/etc...>/
+  whoami: updates_release_2.61.0 # To view staged javadocs/pydocs, update staging branch here
+  subdir: content/releases
+
 publish:
   whoami: release-docs
   subdir: content/releases


### PR DESCRIPTION
This follows https://github.com/apache/infrastructure-asfyaml?tab=readme-ov-file#web-site-deployment-service-for-git-repositories to add a staging site. I think this is the right way to do it, but I'm not totally sure. Worst case, we can revert.

I want to do this so that we can test https://github.com/apache/beam/issues/32901
